### PR TITLE
Enable driver to see broadcast packets 

### DIFF
--- a/Dockerfile-relay
+++ b/Dockerfile-relay
@@ -1,5 +1,4 @@
-#FROM databoxsystems/base-image-ocaml:alpine-3.4_ocaml-4.04.2 as BUILDER
-FROM ocaml/opam:alpine-3.6_ocaml-4.04.2 as BUILDER
+FROM ocaml/opam:alpine-3.6_ocaml-4.04.2 as builder
 
 WORKDIR /core-network
 ADD core-network.export core-network.export
@@ -10,18 +9,15 @@ RUN sudo apk update && sudo apk add alpine-sdk bash gmp-dev perl autoconf linux-
     opam switch import core-network.export
 
 ADD . .
-RUN sudo chown opam: -R . && opam config exec -- jbuilder build bin/core_network.exe
+RUN sudo chown opam: -R . && opam config exec -- jbuilder build bin/relay.exe
 
 
 FROM alpine:3.6
 
 WORKDIR /core-network
-ADD start.sh start.sh
 RUN apk update && apk add bash gmp-dev iptables iproute2 tcpdump
-COPY --from=BUILDER /core-network/_build/default/bin/core_network.exe core-network
+COPY --from=builder /core-network/_build/default/bin/relay.exe bcast-relay
 
-EXPOSE 8080
+LABEL databox.type="core-network-broadcast-relay"
 
-LABEL databox.type="core-network"
-
-ENTRYPOINT ["./start.sh"]
+ENTRYPOINT ["./bcast-relay"]

--- a/bin/core_network.ml
+++ b/bin/core_network.ml
@@ -28,6 +28,7 @@ let main fifo logs =
 let logs =
   let doc = "set source-dependent logging level, eg: --logs *:info,foo:debug" in
   let src_levels = [
+    `Src "bcast",      Logs.Info;
     `Src "core",       Logs.Info;
     `Src "junction",   Logs.Info;
     `Src "dns",        Logs.Info;

--- a/bin/jbuild
+++ b/bin/jbuild
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
-(executable
-  ((name core_network)
+(executables
+  ((names (core_network relay))
    (libraries
      (lib_core_network
       lwt lwt.unix logs cmdliner))))

--- a/bin/relay.ml
+++ b/bin/relay.ml
@@ -1,0 +1,110 @@
+open Lwt.Infix
+open Lib_core_network
+
+let intf = Logs.Src.create "relay" ~doc:"Bcast traffic relay"
+module Log = (val Logs_lwt.src_log intf : Logs_lwt.LOG)
+
+let existed_intf () =
+  let command = "ip", [|"ip"; "address"; "show"|] in
+  let st = Lwt_process.pread_lines command in
+  Lwt_stream.to_list st >>= fun lines ->
+  let regex = "inet (([0-9]+.){3}[0-9]+/[0-9]+) .*(eth[0-9]+)$" in
+  let re = Re_posix.(regex |> re |> compile) in
+  List.fold_left (fun acc line ->
+      try let groups = Re.exec re line |> Re.Group.all in
+        let dev = groups.(3) and addr = groups.(1) in
+        (dev, addr) :: acc
+      with Not_found -> acc) [] lines
+  |> List.rev
+  |> fun existed ->
+  Log.info (fun m -> m "found %d existed phy interfaces" (List.length existed)) >>= fun () ->
+  Lwt_list.iter_p (fun (dev, cidr_addr) ->
+    Log.info (fun m -> m "%s: %s" dev cidr_addr)) existed >>= fun () ->
+  Lwt.return existed
+
+let host_net host_ip existed =
+  List.fold_left (fun acc (dev, cidr_addr) ->
+    let _, ip = Ipaddr.V4.Prefix.of_address_string_exn cidr_addr in
+    if host_ip = Ipaddr.V4.to_string ip then (dev, cidr_addr) :: acc
+    else acc) [] existed
+  |> fun hosts ->
+    if 0 <> List.length hosts then
+      let dev, cidr = List.hd hosts in
+      Intf.create ~dev ~cidr
+    else
+      Log.err (fun m -> m "no interface with address %s found" host_ip)
+      >>= fun () -> Lwt.fail_invalid_arg host_ip
+
+let broadcast consume intf =
+  let broad_dst = Ipaddr.V4.Prefix.broadcast intf.Intf.network in
+  let recvfrom intf =
+    Lwt_stream.get intf.Intf.recv_st >>= function
+    | Some pkt ->
+      let dst = Ipv4_wire.get_ipv4_dst pkt |> Ipaddr.V4.of_int32 in
+      if 0 = Ipaddr.V4.compare dst broad_dst then
+        let buf_len = Cstruct.len pkt in
+        let pkt_len = Ipv4_wire.get_ipv4_len pkt in
+        Log.debug (fun m -> m "got one broadcast pkt: %d %d" pkt_len buf_len) >>= fun () ->
+        consume pkt
+      else Lwt.return_unit
+    | None -> Log.warn (fun m -> m "recv stream from %s closed!" intf.Intf.dev) in
+  let rec loop () =
+    recvfrom intf
+    >>= loop in
+  loop ()
+
+(* name: absolute path *)
+let open_fifo name =
+  (*check for existence and file type*)
+  let fd = Unix.openfile name [Unix.O_WRONLY] 0o640 in
+  Lwt.return fd
+
+let write_fifo fd buf =
+  let buff = Cstruct.to_string buf in
+  let len = Cstruct.len buf in
+  let cnt = ref 0 in
+  try
+    while !cnt < len do
+      let wcnt = Unix.write fd buff !cnt (len - !cnt) in
+      cnt := !cnt + wcnt
+    done;
+    Lwt.return_unit
+  with err -> Lwt.fail err
+
+let start host_ip fd =
+  existed_intf ()
+  >>= host_net host_ip
+  >>= fun (intf, intf_starter) ->
+  broadcast (write_fifo fd) intf <&> intf_starter ()
+
+
+open Cmdliner
+
+let main host_ip fifo logs =
+  Utils.Log.set_up_logs logs >>= fun () ->
+  open_fifo fifo >>= fun fd ->
+  start host_ip fd
+
+let logs =
+  let doc = "set source-dependent logging level, eg: --logs *:info,foo:debug" in
+  let src_levels = [`Src "relay", Logs.Info] in
+  Arg.(value & opt (list Utils.Log.log_threshold) src_levels & info ["l"; "logs"] ~doc ~docv:"LEVEL")
+
+let host =
+  let doc = "set host IP address of relay broadcast traffic from" in
+  Arg.(required & opt (some string) None & info ["h"; "host"] ~doc ~docv:"HOST")
+
+let fifo_name =
+  let doc = "absolute path to fifo to write broadcast packet into" in
+  Arg.(required & opt (some string) None & info ["f"; "file"] ~doc ~docv:"FIFO")
+
+let cmd =
+  let doc = "broadcast traffic relay from host to core-network" in
+  Term.(const main $ host $ fifo_name $ logs),
+  Term.info "relay" ~doc ~man:[]
+
+
+let () =
+  match Term.eval cmd with
+  | `Ok t -> Lwt_main.run t
+  | _ -> exit 1

--- a/lib/bcast.ml
+++ b/lib/bcast.ml
@@ -1,0 +1,43 @@
+open Lwt.Infix
+
+let bcast = Logs.Src.create "bcast" ~doc:"Broadcast traffic repeater"
+module Log = (val Logs_lwt.src_log bcast : Logs_lwt.LOG)
+
+
+let no_broadcast () = Lwt.return_unit
+
+let open_fifo name = Lwt_unix.openfile name [Unix.O_RDONLY] 0o640
+
+let read_len fd buf len =
+  let rec read cnt buf =
+    if cnt = len then Lwt.return_unit else
+      Lwt_cstruct.read fd buf >>= fun rlen ->
+      read (cnt + rlen) (Cstruct.shift buf rlen) in
+  read 0 buf
+
+let extract_bcast_pkt fd hd () =
+  Lwt.catch (fun () ->
+    read_len fd hd 2 >>= fun () ->
+    Lwt.return @@ Cstruct.BE.get_uint16 hd 0 >>= fun pkt_len ->
+    let pkt = Cstruct.create pkt_len in
+    read_len fd pkt pkt_len >>= fun () ->
+    Lwt.return_some pkt)
+  (fun exn ->
+    Log.err (fun m -> m "extract_bcast_pkt %s" (Printexc.to_string exn))
+    >>= fun () -> Lwt.return_none)
+
+
+let create ?fifo interfaces =
+  match fifo with
+  | None -> Lwt.return no_broadcast
+  | Some fname ->
+    open_fifo fname >>= fun fd ->
+    let hd = Cstruct.create 2 in
+    let pkt_stm = Lwt_stream.from (extract_bcast_pkt fd hd) in
+    let rec relay_lp () =
+      Lwt_stream.get pkt_stm >>= function
+      | Some pkt ->
+          Interfaces.relay_bcast interfaces pkt;
+          relay_lp ()
+      | None -> Lwt.return_unit in
+    Lwt.return relay_lp

--- a/lib/bcast.ml
+++ b/lib/bcast.ml
@@ -37,6 +37,7 @@ let create ?fifo interfaces =
     let rec relay_lp () =
       Lwt_stream.get pkt_stm >>= function
       | Some pkt ->
+          Log.debug (fun m -> m "got one broadcast pkt: %d" (Cstruct.len pkt)) >>= fun () ->
           Interfaces.relay_bcast interfaces pkt;
           relay_lp ()
       | None -> Lwt.return_unit in

--- a/lib/interfaces.ml
+++ b/lib/interfaces.ml
@@ -171,22 +171,23 @@ let set_tcp_checksum buf ph =
   let csum = Tcpip_checksum.ones_complement_list [ph; buf] in
   Tcp.Tcp_wire.set_tcp_checksum buf csum
 
-let with_ip_dst dst_ip pkt =
+let with_ip_pair src_ip dst_ip pkt =
   let not_expected log =
     Log.err (fun m -> m "%s not expected value in with_ip_dst" log) >>= fun () ->
     Lwt.fail (Invalid_argument log) in
   let open Frame in
   match parse_ipv4_pkt pkt with
-  | Ok (Ipv4 {src; ihl; raw = nat_buf; payload}) ->
+  | Ok (Ipv4 {ihl; raw = nat_buf; payload}) ->
+      Ipv4_wire.set_ipv4_src nat_buf (Ipaddr.V4.to_int32 src_ip);
       Ipv4_wire.set_ipv4_dst nat_buf (Ipaddr.V4.to_int32 dst_ip);
       set_ipv4_checksum nat_buf ihl;
       (match payload with
       | Udp {len; raw = udp_buf} ->
-          let ph = Ipv4_packet.Marshal.pseudoheader ~src ~dst:dst_ip ~proto:`UDP len in
+          let ph = Ipv4_packet.Marshal.pseudoheader ~src:src_ip ~dst:dst_ip ~proto:`UDP len in
           set_udp_checksum udp_buf ph
       | Tcp {raw = tcp_buf} ->
           let len = Cstruct.len tcp_buf in
-          let ph = Ipv4_packet.Marshal.pseudoheader ~src ~dst:dst_ip ~proto:`TCP len in
+          let ph = Ipv4_packet.Marshal.pseudoheader ~src:src_ip ~dst:dst_ip ~proto:`TCP len in
           set_tcp_checksum tcp_buf ph
       | Icmp _ -> ()
       | _ -> Lwt.ignore_result @@ not_expected "ipv4_payload")
@@ -199,7 +200,7 @@ let relay_bcast t pkt =
       let pkt_len = Cstruct.len pkt in
       let pkt' = Cstruct.create pkt_len in
       let () = Cstruct.blit pkt 0 pkt' 0 pkt_len in
-      let () = with_ip_dst dst pkt' in
+      let () = with_ip_pair intf.Intf.ip dst pkt' in
       intf.Intf.send_push (Some pkt')) t.interfaces
 
 let create () =

--- a/lib/interfaces.ml
+++ b/lib/interfaces.ml
@@ -194,12 +194,13 @@ let with_ip_dst dst_ip pkt =
 
 let relay_bcast t pkt =
   IntfSet.iter (fun intf ->
-    let dst = Ipaddr.V4.Prefix.broadcast intf.Intf.network in
-    let pkt_len = Cstruct.len pkt in
-    let pkt' = Cstruct.create pkt_len in
-    let () = Cstruct.blit pkt 0 pkt' 0 pkt_len in
-    let () = with_ip_dst dst pkt' in
-    intf.Intf.send_push (Some pkt')) t.interfaces
+    if intf.Intf.gateway <> None then () else
+      let dst = Ipaddr.V4.Prefix.broadcast intf.Intf.network in
+      let pkt_len = Cstruct.len pkt in
+      let pkt' = Cstruct.create pkt_len in
+      let () = Cstruct.blit pkt 0 pkt' 0 pkt_len in
+      let () = with_ip_dst dst pkt' in
+      intf.Intf.send_push (Some pkt')) t.interfaces
 
 let create () =
   let interfaces = IntfSet.empty in

--- a/lib/interfaces.mli
+++ b/lib/interfaces.mli
@@ -17,3 +17,5 @@ val from_same_network: t -> Ipaddr.V4.t -> Ipaddr.V4.t -> bool Lwt.t
 val to_push: t -> Ipaddr.V4.t -> Cstruct.t -> unit Lwt.t
 
 val substitute: t -> Ipaddr.V4.t -> Ipaddr.V4.t -> unit Lwt.t
+
+val relay_bcast: t -> Cstruct.t -> unit

--- a/lib/intf.ml
+++ b/lib/intf.ml
@@ -62,6 +62,7 @@ let rec write_intf t eth arp send_st =
         Ethif.writev eth [hd; ipv4_pkt] >>= (function
           | Ok () -> Lwt.return_unit
           | Error e -> Log.err (fun m -> m "%s Ethif.writev %a" t.dev Ethif.pp_error e))
+        >>= fun () -> write_intf t eth arp send_st
       else
         let query_ip =
           if Ipaddr.V4.Prefix.mem dst t.network then dst

--- a/lib/junction.ml
+++ b/lib/junction.ml
@@ -247,7 +247,7 @@ module Dispatcher = struct
 end
 
 
-let create intf_st =
+let create ?fifo intf_st =
   let interfaces = Interfaces.create () in
   let nat = Nat.create () in
   let policy = Policy.create interfaces nat in
@@ -297,4 +297,5 @@ let create intf_st =
     in
 
   Policy.allow_privileged_host policy "arbiter" >>= fun () ->
-  Lwt.return junction_lp
+  Bcast.create ?fifo interfaces >>= fun bcast_starter ->
+  Lwt.return @@ fun () -> junction_lp () <&> bcast_starter ()


### PR DESCRIPTION
This PR enables forwarding of broadcast packets from the host's network interface to drivers for device discovery. 

 Note: it only works on Linux (MacOS/Windows is not supported due to docker VM not having access to the host network interface)

Fixes https://github.com/me-box/databox/issues/227