### PR TITLE
Update docker repo, and mirage-net-psock dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 #FROM databoxsystems/base-image-ocaml:alpine-3.4_ocaml-4.04.2 as BUILDER
-FROM ocaml/opam:alpine-3.6_ocaml-4.04.2 as BUILDER
+FROM ocaml/opam-dev:alpine-3.6_ocaml-4.04.2 as BUILDER
 
 WORKDIR /core-network
 ADD core-network.export core-network.export
 
 RUN sudo apk update && sudo apk add alpine-sdk bash gmp-dev perl autoconf linux-headers &&\
     #opam remote add git https://github.com/ocaml/opam-repository.git &&\
-    opam pin add -n mirage-net-psock.0.1.0 https://github.com/sevenEng/mirage-net-psock.git &&\
-    opam switch import core-network.export
+    opam pin add -n mirage-net-psock.0.1.0 https://github.com/sevenEng/mirage-net-psock.git#921900d502504ac46ef63b52935e4398d24647f4 -y &&\
+    opam switch import core-network.export -y
 
 ADD . .
 RUN sudo chown opam: -R . && opam config exec -- jbuilder build bin/core_network.exe

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 #FROM databoxsystems/base-image-ocaml:alpine-3.4_ocaml-4.04.2 as BUILDER
-FROM ocaml/opam-dev:alpine-3.6_ocaml-4.04.2 as BUILDER
+FROM ocaml/opam2:alpine-3.7-ocaml-4.04 as BUILDER
+
+ENV OCAMLYES=true
 
 WORKDIR /core-network
 ADD core-network.export core-network.export
 
 RUN sudo apk update && sudo apk add alpine-sdk bash gmp-dev perl autoconf linux-headers &&\
     #opam remote add git https://github.com/ocaml/opam-repository.git &&\
-    opam pin add -n mirage-net-psock.0.1.0 https://github.com/sevenEng/mirage-net-psock.git#921900d502504ac46ef63b52935e4398d24647f4 -y &&\
-    opam switch import core-network.export -y
+    opam pin add -n mirage-net-psock.0.1.0 https://github.com/sevenEng/mirage-net-psock.git#921900d502504ac46ef63b52935e4398d24647f4 &&\
+    opam switch import core-network.export
 
 ADD . .
 RUN sudo chown opam: -R . && opam config exec -- jbuilder build bin/core_network.exe

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #FROM databoxsystems/base-image-ocaml:alpine-3.4_ocaml-4.04.2 as BUILDER
 FROM ocaml/opam2:alpine-3.7-ocaml-4.04 as BUILDER
 
-ENV OCAMLYES=true
+ENV OPAMYES=true
 
 WORKDIR /core-network
 ADD core-network.export core-network.export

--- a/Dockerfile-aarch64
+++ b/Dockerfile-aarch64
@@ -3,7 +3,7 @@ FROM jptmoore/alpine-baseimage-aarch64
 USER databox
 RUN sudo apk add libffi-dev libressl-dev linux-headers bash autoconf
 RUN opam remove ezirmin irmin re.1.7.1 bos lwt
-RUN opam pin add -n mirage-net-psock.0.1.0 https://github.com/sevenEng/mirage-net-psock.git
+RUN opam pin add -n mirage-net-psock.0.1.0 https://github.com/sevenEng/mirage-net-psock.git#921900d502504ac46ef63b52935e4398d24647f4 -y
 
 ADD core-network.export core-network.export
 RUN opam switch import core-network.export

--- a/Dockerfile-relay
+++ b/Dockerfile-relay
@@ -3,7 +3,7 @@ FROM ocaml/opam2:alpine-3.7-ocaml-4.04 as BUILDER
 WORKDIR /core-network
 ADD core-network.export core-network.export
 
-ENV OCAMLYES=true
+ENV OPAMYES=true
 
 RUN sudo apk update && sudo apk add alpine-sdk bash gmp-dev perl autoconf linux-headers &&\
     #opam remote add git https://github.com/ocaml/opam-repository.git &&\

--- a/Dockerfile-relay
+++ b/Dockerfile-relay
@@ -1,12 +1,12 @@
-FROM ocaml/opam:alpine-3.6_ocaml-4.04.2 as builder
+FROM ocaml/opam-dev:alpine-3.6_ocaml-4.04.2 as builder
 
 WORKDIR /core-network
 ADD core-network.export core-network.export
 
 RUN sudo apk update && sudo apk add alpine-sdk bash gmp-dev perl autoconf linux-headers &&\
     #opam remote add git https://github.com/ocaml/opam-repository.git &&\
-    opam pin add -n mirage-net-psock.0.1.0 https://github.com/sevenEng/mirage-net-psock.git &&\
-    opam switch import core-network.export
+    opam pin add -n mirage-net-psock.0.1.0 https://github.com/sevenEng/mirage-net-psock.git#921900d502504ac46ef63b52935e4398d24647f4 -y &&\
+    opam switch import core-network.export -y
 
 ADD . .
 RUN sudo chown opam: -R . && opam config exec -- jbuilder build bin/relay.exe

--- a/Dockerfile-relay
+++ b/Dockerfile-relay
@@ -1,12 +1,14 @@
-FROM ocaml/opam-dev:alpine-3.6_ocaml-4.04.2 as builder
+FROM ocaml/opam2:alpine-3.7-ocaml-4.04 as BUILDER
 
 WORKDIR /core-network
 ADD core-network.export core-network.export
 
+ENV OCAMLYES=true
+
 RUN sudo apk update && sudo apk add alpine-sdk bash gmp-dev perl autoconf linux-headers &&\
     #opam remote add git https://github.com/ocaml/opam-repository.git &&\
-    opam pin add -n mirage-net-psock.0.1.0 https://github.com/sevenEng/mirage-net-psock.git#921900d502504ac46ef63b52935e4398d24647f4 -y &&\
-    opam switch import core-network.export -y
+    opam pin add -n mirage-net-psock.0.1.0 https://github.com/sevenEng/mirage-net-psock.git#921900d502504ac46ef63b52935e4398d24647f4 &&\
+    opam switch import core-network.export
 
 ADD . .
 RUN sudo chown opam: -R . && opam config exec -- jbuilder build bin/relay.exe

--- a/Dockerfile-relay-aarch64
+++ b/Dockerfile-relay-aarch64
@@ -2,11 +2,11 @@ FROM jptmoore/alpine-baseimage-aarch64
 
 USER databox
 RUN sudo apk add libffi-dev libressl-dev linux-headers bash autoconf
-RUN opam remove ezirmin irmin re.1.7.1 bos lwt
-RUN opam pin add -n mirage-net-psock.0.1.0 https://github.com/sevenEng/mirage-net-psock.git
+RUN opam remove ezirmin irmin re.1.7.1 bos lwt -y
+RUN opam pin add -n mirage-net-psock.0.1.0 https://github.com/sevenEng/mirage-net-psock.git#921900d502504ac46ef63b52935e4398d24647f4 -y
 
 ADD core-network.export core-network.export
-RUN opam switch import core-network.export
+RUN opam switch import core-network.export -y
 
 # add the code
 ADD bin bin

--- a/test/core-network-test
+++ b/test/core-network-test
@@ -34,6 +34,7 @@ docker swarm init --advertise-addr $EXT_IP > /dev/null
 docker network create -d overlay --attachable databox-system-net >/dev/null
 
 err "start core-network..."
+docker-compose -f ./docker-core-network.yaml build
 docker-compose -f ./docker-core-network.yaml up -d
 _exec node ./src/createResolvConf.js "$(docker inspect $(docker ps -q --filter="name=databox-network"))"
 


### PR DESCRIPTION
The name for opam docker image has changed and mirage-net-psock needs to be pinned against an old version of the repo to allow it to build. This PR fixes both of those issues.

(additional `-y`s to allow docker building)